### PR TITLE
New property for additional arguments to be passed to the console emulator

### DIFF
--- a/ConEmuWinForms/ConEmuSession.cs
+++ b/ConEmuWinForms/ConEmuSession.cs
@@ -496,6 +496,11 @@ namespace ConEmu.WinForms
 			}
 			cmdl.AppendSwitchIfNotNull("-cur_console:", $"{(startinfo.IsElevated ? "a" : "")}{sConsoleExitMode}");
 
+			if (!string.IsNullOrEmpty(startinfo.ConsoleProcessExtraArgs))
+			{
+				cmdl.AppendSwitch(startinfo.ConsoleProcessExtraArgs);
+			}
+
 			// And the shell command line itself
 			cmdl.AppendSwitch(startinfo.ConsoleProcessCommandLine);
 

--- a/ConEmuWinForms/ConEmuStartInfo.cs
+++ b/ConEmuWinForms/ConEmuStartInfo.cs
@@ -51,6 +51,9 @@ namespace ConEmu.WinForms
 		[NotNull]
 		private string _sConsoleProcessCommandLine = ConEmuConstants.DefaultConsoleCommandLine;
 
+		[CanBeNull]
+		private string _sConsoleProcessExtraArgs;
+
 		[NotNull]
 		private string _sGreetingText = "";
 
@@ -242,6 +245,24 @@ namespace ConEmu.WinForms
 					throw new ArgumentNullException(nameof(value));
 				AssertNotUsedUp();
 				_sConsoleProcessCommandLine = value;
+			}
+		}
+
+		/// <summary>
+		///     <para>Additional arguments to be passed to the console emulator.</para>
+		///     <para>This property cannot be changed when the process is running.</para>
+		/// </summary>
+		[CanBeNull]
+		public string ConsoleProcessExtraArgs
+		{
+			get
+			{
+				return _sConsoleProcessExtraArgs;
+			}
+			set
+			{
+				AssertNotUsedUp();
+				_sConsoleProcessExtraArgs = value;
 			}
 		}
 


### PR DESCRIPTION
I want to pass extra args but I don't want them to be visible as a part of an executed command line.
